### PR TITLE
Add some missing shapes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+# IDE
+/.idea/
+*.iml
+.vscode

--- a/shape/mxActor.d.ts
+++ b/shape/mxActor.d.ts
@@ -1,0 +1,42 @@
+///<reference path="mxShape.d.ts"/>
+///<reference path="../util/mxAbstractCanvas2D.d.ts"/>
+///<reference path="../util/mxRectangle.d.ts"/>
+/**
+ * Extends {@link mxShape} to implement an actor shape. If a custom shape with one
+ * filled area is needed, then this shape's {@link redrawPath} method should be overridden.
+ *
+ * This shape is registered under {@link mxConstants.SHAPE_ACTOR} in {@link mxCellRenderer}.
+ *
+ * @example
+ * ```javascript
+ * function SampleShape() { }
+ *
+ * SampleShape.prototype = new mxActor();
+ * SampleShape.prototype.constructor = vsAseShape;
+ *
+ * mxCellRenderer.registerShape('sample', SampleShape);
+ * SampleShape.prototype.redrawPath = function(path, x, y, w, h)
+ * {
+ *   path.moveTo(0, 0);
+ *   path.lineTo(w, h);
+ *   // ...
+ *   path.close();
+ * }
+ * ```
+ */
+declare class mxActor extends mxShape {
+  /**
+   * Constructs a new actor shape.
+   *
+   * @param bounds         {@link mxRectangle} that defines the bounds. This is stored in {@link mxShape.bounds}.
+   * @param fill           String that defines the fill color. This is stored in {@link mxShape.fill}.
+   * @param stroke         String that defines the stroke color. This is stored in {@link mxShape.stroke}.
+   * @param strokewidth    Optional integer that defines the stroke width. Default is 1. This is stored in {@link mxShape.strokewidth}.
+   */
+  constructor(bounds: mxRectangle, fill: string, stroke: string, strokewidth?: number);
+
+  /**
+   * Draws the path for this shape.
+   */
+  redrawPath(c: mxAbstractCanvas2D, x: number, y: number, w: number, h: number): void;
+}

--- a/shape/mxArrow.d.ts
+++ b/shape/mxArrow.d.ts
@@ -1,0 +1,34 @@
+///<reference path="mxShape.d.ts"/>
+///<reference path="../util/mxAbstractCanvas2D.d.ts"/>
+///<reference path="../util/mxPoint.d.ts"/>
+///<reference path="../util/mxRectangle.d.ts"/>
+/**
+ * Extends {@link mxShape} to implement an arrow shape. The shape is used to represent edges, not vertices.
+ *
+ * This shape is registered under {@link mxConstants.SHAPE_ARROW} in {@link mxCellRenderer}.
+ */
+declare class mxArrow extends mxShape {
+
+  /**
+   * Constructs a new arrow shape.
+   *
+   * @param points         Array of {@link mxPoint} that define the points. This is stored in {@link mxShape.points}.
+   * @param fill           String that defines the fill color. This is stored in {@link mxShape.fill}.
+   * @param stroke         String that defines the stroke color. This is stored in {@link mxShape.stroke}.
+   * @param strokewidth    Optional integer that defines the stroke width. Default is 1. This is stored in {@link mxShape.strokewidth}.
+   * @param arrowWidth     Optional integer that defines the arrow width. Default is {@link mxConstants.ARROW_WIDTH}. This is stored in {@link mxShape.arrowWidth}.
+   * @param spacing        Optional integer that defines the spacing between the arrow shape and its endpoints. Default is {@link mxConstants.ARROW_SPACING}. This is stored in {@link mxShape.spacing}.
+   * @param endSize        Optional integer that defines the size of the arrowhead. Default is {@link mxConstants.ARROW_SIZE}. This is stored in {@link mxShape.endSize}.
+   */
+  constructor(points: mxPoint[], fill: string, stroke: string, strokewidth?: number, arrowWidth?: number, spacing?: number, endSize?: number);
+
+  /**
+   * Augments the bounding box with the edge width and markers.
+   */
+  augmentBoundingBox(bbox: mxRectangle): void;
+
+  /**
+   * Paints the line shape.
+   */
+  paintEdgeShape(c: mxAbstractCanvas2D, pts: mxPoint[]): void;
+}

--- a/shape/mxArrowConnector.d.ts
+++ b/shape/mxArrowConnector.d.ts
@@ -1,0 +1,90 @@
+///<reference path="mxShape.d.ts"/>
+///<reference path="../util/mxAbstractCanvas2D.d.ts"/>
+///<reference path="../util/mxPoint.d.ts"/>
+///<reference path="../util/mxRectangle.d.ts"/>
+///<reference path="../view/mxCellState.d.ts"/>
+/**
+ * Extends {@link mxShape} to implement an new rounded arrow shape with support for waypoints and double arrows. The
+ * shape is used to represent edges, not vertices.
+ *
+ * This shape is registered under {@link mxConstants.SHAPE_ARROW_CONNECTOR} in {@link mxCellRenderer}.
+ */
+declare class mxArrowConnector extends mxShape {
+
+  /**
+   * Constructs a new arrow shape.
+   *
+   * @param points         Array of {@link mxPoint} that define the points. This is stored in {@link mxShape.points}.
+   * @param fill           String that defines the fill color. This is stored in {@link mxShape.fill}.
+   * @param stroke         String that defines the stroke color. This is stored in {@link mxShape.stroke}.
+   * @param strokewidth    Optional integer that defines the stroke width. Default is 1. This is stored in {@link mxShape.strokewidth}.
+   * @param arrowWidth     Optional integer that defines the arrow width. Default is {@link mxConstants.ARROW_WIDTH}. This is stored in {@link mxShape.arrowWidth}.
+   * @param spacing        Optional integer that defines the spacing between the arrow shape and its endpoints. Default is {@link mxConstants.ARROW_SPACING}. This is stored in {@link mxShape.spacing}.
+   * @param endSize        Optional integer that defines the size of the arrowhead. Default is {@link mxConstants.ARROW_SIZE}. This is stored in {@link mxShape.endSize}.
+   */
+  constructor(points: mxPoint[], fill: string, stroke: string, strokewidth: number, arrowWidth?: number, spacing?: number, endSize?: number);
+
+  /**
+   * Allows to use the SVG bounding box in SVG.
+   * @defaultValue `false` for performance reasons.
+   */
+  useSvgBoundingBox: boolean;
+
+  /**
+   * Overrides mxShape to reset spacing.
+   */
+  resetStyles(): void;
+
+  /**
+   * Overrides apply to get smooth transition from default start- and endsize.
+   */
+  apply(state: mxCellState): void;
+
+  /**
+   * Augments the bounding box with the edge width and markers.
+   */
+  augmentBoundingBox(bbox: mxRectangle);
+
+  /**
+   * Paints the line shape.
+   */
+  paintEdgeShape(c: mxAbstractCanvas2D, pts: mxPoint[]): void;
+
+
+  paintMarker(c: mxAbstractCanvas2D, ptX: number, ptY: number, nx: number, ny: number, size: number, arrowWidth: number, edgeWidth: number, spacing: number, initialMove: boolean): void;
+
+  /**
+   * @returns whether the arrow is rounded
+   */
+  isArrowRounded(): boolean;
+
+  /**
+   * @returns the width of the start arrow
+   */
+  getStartArrowWidth(): number;
+
+  /**
+   * @returns the width of the end arrow
+   */
+  getEndArrowWidth(): number;
+
+  /**
+   * @returns the width of the body of the edge
+   */
+  getEdgeWidth(): number;
+
+  /**
+   * @returns whether the ends of the shape are drawn
+   */
+  isOpenEnded(): boolean;
+
+  /**
+   * @returns whether the start marker is drawn
+   */
+  isMarkerStart(): boolean;
+
+  /**
+   * @returns whether the end marker is drawn
+   */
+  isMarkerEnd(): boolean;
+}

--- a/shape/mxCloud.d.ts
+++ b/shape/mxCloud.d.ts
@@ -1,0 +1,23 @@
+///<reference path="mxActor.d.ts"/>
+/**
+ * Extends {@link mxActor} to implement a cloud shape.
+ *
+ * This shape is registered under {@link mxConstants.SHAPE_CLOUD} in {@link mxCellRenderer}.
+ */
+declare class mxCloud extends mxActor {
+
+  /**
+   * Constructs a new actor shape.
+   *
+   * @param bounds         {@link mxRectangle} that defines the bounds. This is stored in {@link mxShape.bounds}.
+   * @param fill           String that defines the fill color. This is stored in {@link mxShape.fill}.
+   * @param stroke         String that defines the stroke color. This is stored in {@link mxShape.stroke}.
+   * @param strokewidth    Optional integer that defines the stroke width. Default is 1. This is stored in {@link mxShape.strokewidth}.
+   */
+  constructor(bounds: mxRectangle, fill: string, stroke: string, strokewidth?: number);
+
+  /**
+   * Draws the path for this shape.
+   */
+  redrawPath(c: mxAbstractCanvas2D, x: number, y: number, w: number, h: number): void;
+}

--- a/shape/mxCylinder.d.ts
+++ b/shape/mxCylinder.d.ts
@@ -1,0 +1,42 @@
+///<reference path="mxShape.d.ts"/>
+///<reference path="../util/mxAbstractCanvas2D.d.ts"/>
+///<reference path="../util/mxRectangle.d.ts"/>
+/**
+ * Extends {@link mxShape} to implement an cylinder shape. If a custom shape with one filled area and an overlay path is
+ * needed, then this shape's {@link redrawPath} should be overridden.
+ *
+ * This shape is registered under {@link mxConstants.SHAPE_CYLINDER} in {@link mxCellRenderer}.
+ */
+declare class mxCylinder extends mxShape {
+  /**
+   * Constructs a new cylinder shape.
+   *
+   * @param bounds         {@link mxRectangle} that defines the bounds. This is stored in {@link mxShape.bounds}.
+   * @param fill           String that defines the fill color. This is stored in {@link mxShape.fill}.
+   * @param stroke         String that defines the stroke color. This is stored in {@link mxShape.stroke}.
+   * @param strokewidth    Optional integer that defines the stroke width. Default is 1. This is stored in {@link mxShape.strokewidth}.
+   */
+  constructor(bounds: mxRectangle, fill: string, stroke: string, strokewidth?: number);
+
+  /**
+   * Defines the maximum height of the top and bottom part of the cylinder shape.
+   */
+  maxHeight: number;
+
+  /**
+   * Sets stroke tolerance to 0 for SVG.
+   */
+  svgStrokeTolerance: number;
+
+  /**
+   * Redirects to redrawPath for subclasses to work.
+   */
+  paintVertexShape(c: mxAbstractCanvas2D, x: number, y: number, w: number, h: number): void;
+
+  getCylinderSize(x: number, y: number, w: number, h: number): number;
+
+  /**
+   * Draws the path for this shape.
+   */
+  redrawPath(c: mxAbstractCanvas2D, x: number, y: number, w: number, h: number, isForeground: boolean): void;
+}

--- a/shape/mxDoubleEllipse.d.ts
+++ b/shape/mxDoubleEllipse.d.ts
@@ -1,0 +1,64 @@
+///<reference path="mxShape.d.ts"/>
+///<reference path="../util/mxAbstractCanvas2D.d.ts"/>
+///<reference path="../util/mxRectangle.d.ts"/>
+/**
+ * Extends {@link mxShape} to implement a double ellipse shape.
+ *
+ * This shape is registered under {@link mxConstants.SHAPE_DOUBLE_ELLIPSE} in {@link mxCellRenderer}.
+ *
+ * Use the following override to only fill the inner ellipse in this shape:
+ * @example
+ * ```javascript
+ * mxDoubleEllipse.prototype.paintVertexShape = function(c, x, y, w, h)
+ * {
+ *   c.ellipse(x, y, w, h);
+ *   c.stroke();
+ *
+ *   var inset = mxUtils.getValue(this.style, mxConstants.STYLE_MARGIN, Math.min(3 + this.strokewidth, Math.min(w / 5, h / 5)));
+ *   x += inset;
+ *   y += inset;
+ *   w -= 2 * inset;
+ *   h -= 2 * inset;
+ *
+ *   if (w > 0 && h > 0)
+ *   {
+ *     c.ellipse(x, y, w, h);
+ *   }
+ *
+ *   c.fillAndStroke();
+ * };
+ * ```
+ */
+declare class mxDoubleEllipse extends mxShape {
+
+  /**
+   * Constructs a new ellipse shape.
+   *
+   * @param bounds         {@link mxRectangle} that defines the bounds. This is stored in {@link mxShape.bounds}.
+   * @param fill           String that defines the fill color. This is stored in {@link mxShape.fill}.
+   * @param stroke         String that defines the stroke color. This is stored in {@link mxShape.stroke}.
+   * @param strokewidth    Optional integer that defines the stroke width. Default is 1. This is stored in {@link mxShape.strokewidth}.
+   */
+  constructor(bounds: mxRectangle, fill: string, stroke: string, strokewidth?: number);
+
+  /**
+   * Scale for improving the precision of VML rendering.
+   * @default `10`
+   */
+  mxDoubleEllipse: number;
+
+  /**
+   * Paints the background.
+   */
+  paintBackground(c: mxAbstractCanvas2D, x: number, y: number, w: number, h: number): void;
+
+  /**
+   * Paints the foreground.
+   */
+  paintForeground(c: mxAbstractCanvas2D, x: number, y: number, w: number, h: number): void;
+
+  /**
+   * @returns the bounds for the label.
+   */
+  getLabelBounds(rect: mxRectangle): mxRectangle;
+}


### PR DESCRIPTION
Add
  - mxActor
  - mxArrow
  - mxArrowConnector
  - mxCloud
  - mxCylinder
  - mxDoubleEllipse

I added `reference paths` in definition files because both `IntelliJ` and `VSCode` complains otherwise (unknown types). They are not present in previously existing files, so I don't know if it is something that has been forgotten or issue occurs when they are added.

cc @hungtcs 