### PR TITLE
fix: add missing handlers

### DIFF
--- a/handler/index.d.ts
+++ b/handler/index.d.ts
@@ -1,4 +1,6 @@
+/// <reference path="./mxCellHighlight.d.ts" />
 /// <reference path="./mxCellMarker.d.ts" />
+/// <reference path="./mxCellTracker.d.ts" />
 /// <reference path="./mxConnectionHandler.d.ts" />
 /// <reference path="./mxConstraintHandler.d.ts" />
 /// <reference path="./mxEdgeHandler.d.ts" />

--- a/handler/mxCellHighlight.d.ts
+++ b/handler/mxCellHighlight.d.ts
@@ -1,0 +1,104 @@
+/**
+ * A helper class to highlight cells. Here is an example for a given cell.
+ *
+ * @example
+ * ```javascript
+ * var highlight = new mxCellHighlight(graph, '#ff0000', 2);
+ * highlight.highlight(graph.view.getState(cell)));
+ * ```
+ */
+declare class mxCellHighlight {
+
+  /**
+   * Constructs a cell highlight.
+   *
+   * @param graph
+   * @param highlightColor  default {@link mxConstants.DEFAULT_VALID_COLOR}
+   * @param strokeWidth     default {@link mxConstants.HIGHLIGHT_STROKEWIDTH}
+   * @param dashed          default false
+   */
+  constructor(graph: mxGraph, highlightColor?: string, strokeWidth?: number, dashed?: boolean);
+
+  /**
+   * Specifies if the highlights should appear on top of everything else in the overlay pane.
+   * @default false
+   */
+  keepOnTop: boolean;
+
+  /**
+   * Reference to the enclosing {@link mxGraph}.
+   * @default true
+   */
+  graph: boolean;
+
+  /**
+   * Reference to the {@link mxCellState}.
+   * @default null
+   */
+  state: mxCellState;
+
+  /**
+   * Specifies the spacing between the highlight for vertices and the vertex.
+   * @default 2
+   */
+  spacing: number;
+
+
+  /**
+   * Holds the handler that automatically invokes reset if the highlight should be hidden.
+   * @default null
+   */
+  // TODO find the right type for resetHandler
+  resetHandler: any;
+
+  /**
+   * Sets the color of the rectangle used to highlight drop targets.
+   *
+   * @param {string} color - String that represents the new highlight color.
+   */
+  setHighlightColor(color: string): void;
+
+  /**
+   * Creates and returns the highlight shape for the given state.
+   */
+  drawHighlight(): void;
+
+  /**
+   * Creates and returns the highlight shape for the given state.
+   */
+  createShape(): mxShape;
+
+  /**
+   * Updates the highlight after a change of the model or view.
+   */
+  getStrokeWidth(state: mxCellState): number;
+
+  /**
+   * Updates the highlight after a change of the model or view.
+   */
+  repaint(): void;
+
+
+  /**
+   * Resets the state of the cell marker.
+   */
+  hide(): void;
+
+  /**
+   * Marks the <markedState> and fires a <mark> event.
+   */
+  highlight(state: mxCellState): void;
+
+  /**
+   * Returns true if this highlight is at the given position.
+   */
+  isHighlightAt(x: number, y: number): boolean;
+
+
+  /**
+   * Destroys the handler and all its resources and DOM nodes.
+   */
+  destroy(): void;
+
+}
+

--- a/handler/mxCellTracker.d.ts
+++ b/handler/mxCellTracker.d.ts
@@ -1,0 +1,95 @@
+/**
+ * Event handler that highlights cells
+ *
+ * @example
+ * ```javascript
+ * new mxCellTracker(graph, '#00FF00');
+ * ```
+ *
+ * For detecting dragEnter, dragOver and dragLeave on cells, the following code can be used:
+ * @example
+ * ```javascript
+ * graph.addMouseListener(
+ * {
+ *   cell: null,
+ *   mouseDown: function(sender, me) { },
+ *   mouseMove: function(sender, me)
+ *   {
+ *     var tmp = me.getCell();
+ *
+ *     if (tmp != this.cell)
+ *     {
+ *       if (this.cell != null)
+ *       {
+ *         this.dragLeave(me.getEvent(), this.cell);
+ *       }
+ *
+ *       this.cell = tmp;
+ *
+ *       if (this.cell != null)
+ *       {
+ *         this.dragEnter(me.getEvent(), this.cell);
+ *       }
+ *     }
+ *
+ *     if (this.cell != null)
+ *     {
+ *       this.dragOver(me.getEvent(), this.cell);
+ *     }
+ *   },
+ *   mouseUp: function(sender, me) { },
+ *   dragEnter: function(evt, cell)
+ *   {
+ *     mxLog.debug('dragEnter', cell.value);
+ *   },
+ *   dragOver: function(evt, cell)
+ *   {
+ *     mxLog.debug('dragOver', cell.value);
+ *   },
+ *   dragLeave: function(evt, cell)
+ *   {
+ *     mxLog.debug('dragLeave', cell.value);
+ *   }
+ * });
+ * ```
+ */
+declare class mxCellTracker extends mxCellMarker {
+
+  /**
+   * Constructs an event handler that highlights cells.
+   *
+   * @param graph   Reference to the enclosing {@link mxGraph}.
+   * @param color   Color of the highlight. Default is blue.
+   * @param funct   Optional JavaScript function that is used to override {@link mxCellMarker.getCell}.
+   */
+  constructor(graph: mxGraph, color: string, funct?: Function);
+
+  /**
+   * Ignores the event. The event is not consumed.
+   */
+  // TODO types
+  mouseDown(sender: any, me: mxMouseEvent): void;
+
+  /**
+   * Handles the event by highlighting the cell under the mousepointer if it
+   * is over the hotspot region of the cell.
+   */
+  // TODO types
+  mouseMove(sender: any, me: mxMouseEvent): void;
+
+  /**
+   * Handles the event by resetting the highlight.
+   */
+// TODO types
+  mouseUp(sender: any, me: mxMouseEvent): void
+
+  /**
+   * Function: destroy
+   *
+   * Destroys the object and all its resources and DOM nodes. This doesn't
+   * normally need to be called. It is called automatically when the window
+   * unloads.
+   */
+  destroy(): void;
+
+}


### PR DESCRIPTION
mxCellHighlight and mxCellTracker

**Note**:
- in `mxCellTracker` I didn't know the type for `sender` parameters. I put `any` and added a TODO. If someone already know the actual type, feel free to ammend. Otherwise we will manage this later
- I didn't update the README to mark the `handler` module as `completed` but for sure we now have all classes. Let me know if you think the README should be updated