### PR TITLE
fix(mxConstants): add missing FONT_STRIKETHROUGH

### DIFF
--- a/util/mxConstants.d.ts
+++ b/util/mxConstants.d.ts
@@ -1842,6 +1842,12 @@ declare class mxConstants {
    */
   static FONT_UNDERLINE: 4;
 
+	/**
+	 * Constant for strikthrough fonts. Default is 8.
+   * @since mxgraph 4.1.0
+	 */
+	static FONT_STRIKETHROUGH: 8;
+
   /**
    * Variable: SHAPE_RECTANGLE
    *


### PR DESCRIPTION
Introduced in mxgraph 4.1.0 by https://github.com/jgraph/mxgraph2/commit/650c8e162bc468272b3ea8848fb142868a2b8371