### PR TITLE
Update util/canvas2d types

### DIFF
--- a/util/index.d.ts
+++ b/util/index.d.ts
@@ -21,4 +21,5 @@
 /// <reference path="./mxUrlConverter.d.ts" />
 /// <reference path="./mxUtils.d.ts" />
 /// <reference path="./mxVmlCanvas2D.d.ts" />
+/// <reference path="./mxXmlCanvas2D.d.ts" />
 /// <reference path="./mxXmlRequest.d.ts" />

--- a/util/mxAbstractCanvas2D.d.ts
+++ b/util/mxAbstractCanvas2D.d.ts
@@ -298,7 +298,7 @@ declare abstract class mxAbstractCanvas2D {
   /**
    * Enables or disables and configures the current shadow.
    */
-  setShadowAlpha(value: boolean): void;
+  setShadowAlpha(value: number): void;
 
   /**
    * Enables or disables and configures the current shadow.

--- a/util/mxAbstractCanvas2D.d.ts
+++ b/util/mxAbstractCanvas2D.d.ts
@@ -1,5 +1,8 @@
-
-declare class mxXXState {
+/**
+ * This type does not exist in the mxGraph JavaScript code. It is inferred from the actual implementation
+ * @internal
+ */
+declare interface mxCanvas2DState {
   dx: number;
   dy: number;
   scale: number;
@@ -8,9 +11,9 @@ declare class mxXXState {
   strokeAlpha: number;
   fillColor: string;
   gradientFillAlpha: number;
-  gradientColor: null
+  gradientColor: string;
   gradientAlpha: number;
-  gradientDirection: null
+  gradientDirection: string;
   strokeColor: string;
   strokeWidth: number;
   dashed: boolean;
@@ -20,8 +23,8 @@ declare class mxXXState {
   lineJoin: string;
   miterLimit: number;
   fontColor: string;
-  fontBackgroundColor: null
-  fontBorderColor: null
+  fontBackgroundColor: string;
+  fontBorderColor: string;
   fontSize: number;
   fontFamily: string;
   fontStyle: number;
@@ -35,384 +38,346 @@ declare class mxXXState {
   rotationCy: number;
 }
 
-declare class mxAbstractCanvas2D {
-  constructor();
+/**
+ * Base class for all canvases.
+ * All color values of <mxConstants.NONE> will be converted to null in the state.
+ *
+ * The following methods make up the public interface of the canvas 2D for all painting in mxGraph:
+ * - <save>, <restore>
+ * - <scale>, <translate>, <rotate>
+ * - <setAlpha>, <setFillAlpha>, <setStrokeAlpha>, <setFillColor>, <setGradient>,
+ *   <setStrokeColor>, <setStrokeWidth>, <setDashed>, <setDashPattern>, <setLineCap>,
+ *   <setLineJoin>, <setMiterLimit>
+ * - <setFontColor>, <setFontBackgroundColor>, <setFontBorderColor>, <setFontSize>,
+ *   <setFontFamily>, <setFontStyle>
+ * - <setShadow>, <setShadowColor>, <setShadowAlpha>, <setShadowOffset>
+ * - <rect>, <roundrect>, <ellipse>, <image>, <text>
+ * - <begin>, <moveTo>, <lineTo>, <quadTo>, <curveTo>
+ * - <stroke>, <fill>, <fillAndStroke>
+ *
+ * {@link arcTo} is an additional method for drawing paths. This is a synthetic method, meaning that it is turned into a
+ * sequence of curves by default. Subclassers may add native support for arcs.
+ *
+ * Note: this type is not `abstract` in the mxGraph JavaScript code (ES5) but both its name and its usage shows that
+ * it should not be instantiated and that it only serves as base class for usage and extension.
+ */
+declare abstract class mxAbstractCanvas2D {
+  protected constructor();
 
   /**
-   * Variable: state
-   *
    * Holds the current state.
    */
-  state: mxXXState;
+  state: mxCanvas2DState;
 
   /**
-   * Variable: states
-   *
    * Stack of states.
    */
-  states: mxXXState[];
+  states: mxCanvas2DState[];
 
   /**
-   * Variable: path
-   *
    * Holds the current path as an array.
    */
   path: string[];
 
   /**
-   * Variable: rotateHtml
-   *
-   * Switch for rotation of HTML. Default is false.
+   * Switch for rotation of HTML.
+   * @default true
    */
   rotateHtml: boolean;
 
   /**
-   * Variable: lastX
-   *
    * Holds the last x coordinate.
+   * @default 0
    */
   lastX: number;
 
   /**
-   * Variable: lastY
-   *
    * Holds the last y coordinate.
+   * @default 0
    */
   lastY: number;
 
   /**
-   * Variable: moveOp
-   *
-   * Contains the string used for moving in paths. Default is 'M'.
+   * Contains the string used for moving in paths.
+   * @default 'M'
    */
   moveOp: string;
 
   /**
-   * Variable: lineOp
-   *
-   * Contains the string used for moving in paths. Default is 'L'.
+   * Contains the string used for moving in paths.
+   * @default 'L'
    */
   lineOp: string;
 
   /**
-   * Variable: quadOp
-   *
-   * Contains the string used for quadratic paths. Default is 'Q'.
+   * Contains the string used for quadratic paths.
+   * @default 'Q'
    */
   quadOp: string;
 
   /**
-   * Variable: curveOp
-   *
-   * Contains the string used for bezier curves. Default is 'C'.
+   * Contains the string used for bezier curves.
+   * @default 'C'
    */
   curveOp: string;
 
   /**
-   * Variable: closeOp
-   *
-   * Holds the operator for closing curves. Default is 'Z'.
+   * Holds the operator for closing curves.
+   * @default 'Z'
    */
   closeOp: string;
 
   /**
-   * Variable: pointerEvents
-   *
-   * Boolean value that specifies if events should be handled. Default is false.
+   * Boolean value that specifies if events should be handled.
+   * @default false
    */
   pointerEvents: boolean;
 
   /**
-   * Function: createUrlConverter
-   *
-   * Create a new <mxUrlConverter> and returns it.
+   * Create a new {@link mxUrlConverter} and returns it.
    */
   createUrlConverter(): mxUrlConverter;
 
   /**
-   * Function: reset
-   *
    * Resets the state of this canvas.
    */
   reset(): void;
 
   /**
-   * Function: createState
-   *
    * Creates the state of the this canvas.
    */
-  createState(): HTMLCanvasElement;
+  createState(): mxCanvas2DState;
 
   /**
-   * Function: format
-   *
    * Rounds all numbers to integers.
    */
-  format(value: number): number;
+  format(value: string): number;
 
   /**
-   * Function: addOp
-   *
    * Adds the given operation to the path.
    */
   addOp(): void;
 
   /**
-   * Function: rotatePoint
-   *
    * Rotates the given point and returns the result as an <mxPoint>.
    */
   rotatePoint(x: number, y: number, theta: number, cx: number, cy: number): void;
 
   /**
-   * Function: save
-   *
    * Saves the current state.
    */
   save(): void;
 
   /**
-   * Function: restore
-   *
    * Restores the current state.
    */
   restore(): void;
 
   /**
-   * Function: setLink
-   *
    * Sets the current link. Hook for subclassers.
    */
   setLink(link: string): void;
 
   /**
-   * Function: scale
-   *
    * Scales the current state.
    */
   scale(value: number): void;
 
   /**
-   * Function: translate
-   *
    * Translates the current state.
    */
   translate(dx: number, dy: number): void;
 
   /**
-   * Function: rotate
-   *
    * Rotates the current state.
    */
   rotate(theta: number, flipH: boolean, flipV: boolean, cx: number, cy: number): void;
 
   /**
-   * Function: setAlpha
-   *
    * Sets the current alpha.
    */
   setAlpha(value: number): void;
 
   /**
-   * Function: setFillAlpha
-   *
    * Sets the current solid fill alpha.
    */
   setFillAlpha(value: number): void;
 
   /**
-   * Function: setStrokeAlpha
-   *
    * Sets the current stroke alpha.
    */
   setStrokeAlpha(value: number): void;
 
   /**
-   * Function: setFillColor
-   *
    * Sets the current fill color.
    */
   setFillColor(value: string): void;
 
   /**
-   * Function: setGradient
-   *
    * Sets the current gradient.
    */
   setGradient(color1: string, color2: string, x: number, y: number, w: number, h: number, direction: string, alpha1: number, alpha2: number): void;
 
   /**
-   * Function: setStrokeColor
-   *
    * Sets the current stroke color.
    */
   setStrokeColor(value: string): void;
 
   /**
-   * Function: setStrokeWidth
-   *
    * Sets the current stroke width.
    */
   setStrokeWidth(value: number): void;
 
   /**
-   * Function: setDashed
-   *
    * Enables or disables dashed lines.
+   * @param value specifies whether or not the lines are dashed
+   * @param fixDash specifies whether or not the lines use fix dash
    */
   setDashed(value: boolean, fixDash: boolean): void;
 
   /**
-   * Function: setDashPattern
-   *
    * Sets the current dash pattern.
    */
-  setDashPattern(value: boolean): void;
+  setDashPattern(value: string): void;
+
   /**
-   * Function: setLineCap
-   *
    * Sets the current line cap.
    */
   setLineCap(value: string): void;
 
   /**
-   * Function: setLineJoin
-   *
    * Sets the current line join.
    */
   setLineJoin(value: string): void;
 
   /**
-   * Function: setMiterLimit
-   *
    * Sets the current miter limit.
    */
   setMiterLimit(value: number): void;
 
   /**
-   * Function: setFontColor
-   *
    * Sets the current font color.
    */
   setFontColor(value: string): void;
 
   /**
-   * Function: setFontColor
-   *
    * Sets the current font color.
    */
   setFontBackgroundColor(value: string): void;
 
   /**
-   * Function: setFontColor
-   *
    * Sets the current font color.
    */
   setFontBorderColor(value: string): void;
 
   /**
-   * Function: setFontSize
-   *
    * Sets the current font size.
    */
   setFontSize(value: number): void;
 
   /**
-   * Function: setFontFamily
-   *
    * Sets the current font family.
    */
   setFontFamily(value: string): void;
 
   /**
-   * Function: setFontStyle
-   *
    * Sets the current font style.
    */
   setFontStyle(value: string): void;
 
   /**
-   * Function: setShadow
-   *
    * Enables or disables and configures the current shadow.
    */
   setShadow(enabled: boolean): void;
 
   /**
-   * Function: setShadowColor
-   *
    * Enables or disables and configures the current shadow.
    */
   setShadowColor(value: string): void;
 
   /**
-   * Function: setShadowAlpha
-   *
    * Enables or disables and configures the current shadow.
    */
   setShadowAlpha(value: boolean): void;
 
   /**
-   * Function: setShadowOffset
-   *
    * Enables or disables and configures the current shadow.
    */
   setShadowOffset(dx: number, dy: number): void;
 
   /**
-   * Function: begin
-   *
    * Starts a new path.
    */
   begin(): void;
 
   /**
-   * Function: moveTo
-   *
-   *  Moves the current path the given coordinates.
+   * Moves the current path the given coordinates.
    */
   moveTo(x: number, y: number): void;
 
   /**
-   * Function: lineTo
-   *
    * Draws a line to the given coordinates. Uses moveTo with the op argument.
    */
   lineTo(x: number, y: number): void;
 
   /**
-   * Function: quadTo
-   *
    * Adds a quadratic curve to the current path.
    */
   quadTo(x1: number, y1: number, x2: number, y2: number): void;
 
   /**
-   * Function: curveTo
-   *
    * Adds a bezier curve to the current path.
    */
   curveTo(x1: number, y1: number, x2: number, y2: number, x3: number, y3: number): void;
 
   /**
-   * Function: arcTo
-   *
    * Adds the given arc to the current path. This is a synthetic operation that
    * is broken down into curves.
    */
   arcTo(rx: number, ry: number, angle: number, largeArcFlag: number, sweepFlag: number, x: number, y: number): void;
 
   /**
-   * Function: close
-   *
    * Closes the current path.
+   *
+   * Note: the mxGraph JS code declares arguments (x1: number, y1: number, x2: number, y2: number, x3: number, y3: number)
+   * which are not used in the abstract implementation. The mxXmlCanvas2D JS implementation overrides this method without arguments.
+   * Decision is then taken to remove them here.
    */
-  close(x1: number, y1: number, x2: number, y2: number, x3: number, y3: number): void;
+  close(): void;
 
   /**
-   * Function: end
-   *
    * Empty implementation for backwards compatibility. This will be removed.
    */
   end(): void;
+
+  //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+  //////////////////// Methods inferred from subclasses
+  //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+  // They don't exist in the mxGraph JS code, but all subclasses have them
+  // As mxAbstractCanvas2D is the preferred type when interacting with canvas2D code (for instance, when
+  // developing new classes extending mxShape), these methods are then mandatory.
+
+  /**
+   * Paints the outline of the current path.
+   */
+  stroke(): void;
+
+  /**
+   * Fills the current path.
+   */
+  fill(): void;
+
+  /**
+   * Fills and paints the outline of the current path.
+   */
+  fillAndStroke(): void;
+
+  rect(x: number, y: number, w: number, h: number): void;
+
+  roundrect(x: number, y: number, w: number, h: number, dx: number, dy: number): void;
+
+  ellipse(x: number, y: number, w: number, h: number): void;
+
+  image(x: number, y: number, w: number, h: number, src: string, aspect: boolean, flipH: boolean, flipV: boolean): void;
+
 }

--- a/util/mxSvgCanvas2D.d.ts
+++ b/util/mxSvgCanvas2D.d.ts
@@ -1,166 +1,167 @@
-
-
+/**
+ * Extends {@link mxAbstractCanvas2D} to implement a canvas for SVG. This canvas writes all calls as SVG output to the
+ * given SVG root node.
+ *
+ * @example
+ * ```javascript
+ * var svgDoc = mxUtils.createXmlDocument();
+ * var root = (svgDoc.createElementNS != null) ?
+ * 		svgDoc.createElementNS(mxConstants.NS_SVG, 'svg') : svgDoc.createElement('svg');
+ *
+ * if (svgDoc.createElementNS == null)
+ * {
+ *   root.setAttribute('xmlns', mxConstants.NS_SVG);
+ *   root.setAttribute('xmlns:xlink', mxConstants.NS_XLINK);
+ * }
+ * else
+ * {
+ *   root.setAttributeNS('http://www.w3.org/2000/xmlns/', 'xmlns:xlink', mxConstants.NS_XLINK);
+ * }
+ *
+ * var bounds = graph.getGraphBounds();
+ * root.setAttribute('width', (bounds.x + bounds.width + 4) + 'px');
+ * root.setAttribute('height', (bounds.y + bounds.height + 4) + 'px');
+ * root.setAttribute('version', '1.1');
+ *
+ * svgDoc.appendChild(root);
+ *
+ * var svgCanvas = new mxSvgCanvas2D(root);
+ * ```
+ *
+ *
+ * To disable anti-aliasing in the output, use the following code.
+ * @example
+ * ```javascript
+ * graph.view.canvas.ownerSVGElement.setAttribute('shape-rendering', 'crispEdges');
+ * ```
+ * Or set the respective attribute in the SVG element directly.
+ */
 declare class mxSvgCanvas2D extends mxAbstractCanvas2D {
-
+  /**
+   * @param root          SVG container for the output
+   * @param styleEnabled  Optional boolean that specifies if a style section should be added.
+   *                      The style section sets the default font-size, font-family and stroke-miterlimit globally.
+   *                      Default is `false`.
+   */
   constructor(root: Element, styleEnabled?: boolean);
 
   /**
-   * Variable: root
-   *
    * Reference to the container for the SVG content.
    */
   root: Element;
 
   /**
-   * Variable: gradients
-   *
    * Local cache of gradients for quick lookups.
    */
   gradients: Element[];
 
   /**
-   * Variable: defs
-   *
    * Reference to the defs section of the SVG document. Only for export.
    */
   defs: Element;
 
   /**
-   * Variable: styleEnabled
-   *
    * Stores the value of styleEnabled passed to the constructor.
+   * @default false
    */
   styleEnabled: boolean;
 
   /**
-   * Variable: node
-   *
    * Holds the current DOM node.
    */
   node: Element;
 
   /**
-   * Variable: matchHtmlAlignment
-   *
    * Specifies if plain text output should match the vertical HTML alignment.
-   * Defaul is true.
+   * @default true.
    */
   matchHtmlAlignment: boolean;
 
   /**
-   * Variable: textEnabled
-   *
-   * Specifies if text output should be enabled. Default is true.
+   * Specifies if text output should be enabled.
+   * @default true
    */
   textEnabled: boolean;
 
   /**
-   * Variable: foEnabled
-   *
-   * Specifies if use of foreignObject for HTML markup is allowed. Default is true.
+   * Specifies if use of foreignObject for HTML markup is allowed.
+   * @default true
    */
   foEnabled: boolean;
 
   /**
-   * Variable: foAltText
-   *
-   * Specifies the fallback text for unsupported foreignObjects in exported
-   * documents. Default is '[Object]'. If this is set to null then no fallback
-   * text is added to the exported document.
+   * Specifies the fallback text for unsupported foreignObjects in exported documents.
+   * If this is set to `null` then no fallback text is added to the exported document.
+   * @default [Object]
    */
   foAltText: string;
 
   /**
-   * Variable: foOffset
-   *
    * Offset to be used for foreignObjects.
+   * @default 0
    */
   foOffset: number;
 
   /**
-   * Variable: textOffset
-   *
    * Offset to be used for text elements.
+   * @default 0
    */
   textOffset: number;
 
   /**
-   * Variable: imageOffset
-   *
    * Offset to be used for image elements.
+   * @default 0
    */
   imageOffset: number;
 
   /**
-   * Variable: strokeTolerance
-   *
    * Adds transparent paths for strokes.
+   * @default 0
    */
   strokeTolerance: number;
 
   /**
-   * Variable: minStrokeWidth
-   *
    * Minimum stroke width for output.
+   * @default 1
    */
   minStrokeWidth: number;
 
   /**
-   * Variable: refCount
-   *
    * Local counter for references in SVG export.
+   * @default 0
    */
   refCount: number;
 
   /**
-   * Variable: blockImagePointerEvents
-   *
-   * Specifies if a transparent rectangle should be added on top of images to absorb
-   * all pointer events. Default is false. This is only needed in Firefox to disable
-   * control-clicks on images.
-   */
-  blockImagePointerEvents: boolean;
-
-  /**
-   * Variable: lineHeightCorrection
-   *
-   * Correction factor for <mxConstants.LINE_HEIGHT> in HTML output. Default is 1.
+   * Correction factor for {@link mxConstants.LINE_HEIGHT} in HTML output.
+   * @default 1
    */
   lineHeightCorrection: number;
 
   /**
-   * Variable: pointerEventsValue
-   *
-   * Default value for active pointer events. Default is all.
+   * Default value for active pointer events.
+   * @default all
    */
   pointerEventsValue: string;
 
   /**
-   * Variable: fontMetricsPadding
-   *
-   * Padding to be added for text that is not wrapped to account for differences
-   * in font metrics on different platforms in pixels. Default is 10.
+   * Padding to be added for text that is not wrapped to account for differences in font metrics on different platforms in pixels.
+   * @default 10.
    */
   fontMetricsPadding: number;
 
   /**
-   * Variable: cacheOffsetSize
-   *
-   * Specifies if offsetWidth and offsetHeight should be cached. Default is true.
-   * This is used to speed up repaint of text in <updateText>.
+   * Specifies if offsetWidth and offsetHeight should be cached. This is used to speed up repaint of text in {@link updateText}.
+   * @default true
    */
   cacheOffsetSize: boolean;
 
   /**
-   * Function: format
-   *
    * Rounds all numbers to 2 decimal points.
    */
-  format(value: number): number;
+  format(value: string): number;
 
   /**
-   * Function: getBaseUrl
-   *
    * Returns the URL of the page without the hash part. This needs to use href to
    * include any search part with no params (ie question mark alone). This is a
    * workaround for the fact that window.location.search is empty if there is
@@ -169,177 +170,132 @@ declare class mxSvgCanvas2D extends mxAbstractCanvas2D {
   getBaseUrl(): string;
 
   /**
-   * Function: reset
-   *
    * Returns any offsets for rendering pixels.
    */
   reset(): void;
 
   /**
-   * Function: createStyle
-   *
    * Creates the optional style section.
    */
+  // TODO the x parameter is not used in mxGraph 4.1.1, so unable to infer the type
   createStyle(x?: any): HTMLElement;
 
   /**
-   * Function: createElement
-   *
    * Private helper function to create SVG elements
    */
   createElement(tagName: string, namespace?: string): HTMLElement;
 
   /**
-   * Function: getAlternateContent
-   *
+   * Returns the alternate text string for the given foreignObject.
+   * @since mxgraph 4.1.0
+   */
+  getAlternateText(fo: Element, x: number, y: number, w: number, h: number, str: string, align: string, valign: string, wrap: string, format: string, overflow: string, clip: string, rotation: number): string;
+
+  /**
    * Returns the alternate content for the given foreignObject.
    */
   createAlternateContent(fo: Element, x: number, y: number, w: number, h: number, str: string, align: string, valign: string, wrap: string, format: string, overflow: string, clip: string, rotation: number): Element;
 
   /**
-   * Function: createGradientId
-   *
    * Private helper function to create SVG elements
    */
   createGradientId(start: string, end: string, alpha1: string, alpha2: string, direction: string): string;
 
   /**
-   * Function: getSvgGradient
-   *
    * Private helper function to create SVG elements
    */
-  getSvgGradient(start: string, end: string, alpha1: string, alpha2: string, direction: string): Element;
+  getSvgGradient(start: string, end: string, alpha1: string, alpha2: string, direction: string): string;
 
   /**
-   * Function: createSvgGradient
-   *
    * Creates the given SVG gradient.
    */
   createSvgGradient(start: string, end: string, alpha1: string, alpha2: string, direction: string): Element;
 
   /**
-   * Function: addNode
-   *
    * Private helper function to create SVG elements
    */
-  addNode(filled: boolean, stroked: boolean): Element;
+  addNode(filled: boolean, stroked: boolean): void;
 
   /**
-   * Function: updateFill
-   *
    * Transfers the stroke attributes from <state> to <node>.
    */
   updateFill(): void;
 
   /**
-   * Function: getCurrentStrokeWidth
-   *
    * Returns the current stroke width (>= 1), ie. max(1, this.format(this.state.strokeWidth * this.state.scale)).
    */
   getCurrentStrokeWidth(): number;
 
   /**
-   * Function: updateStroke
-   *
-   * Transfers the stroke attributes from <state> to <node>.
+   * Transfers the stroke attributes from {@link mxAbstractCanvas2D.state} to {@link node}.
    */
   updateStroke(): void;
 
   /**
-   * Function: updateStrokeAttributes
-   *
-   * Transfers the stroke attributes from <state> to <node>.
+   * Transfers the stroke attributes from {@link mxAbstractCanvas2D.state} to {@link node}.
    */
   updateStrokeAttributes(): void;
 
   /**
-   * Function: createDashPattern
-   *
    * Creates the SVG dash pattern for the given state.
    */
-  createDashPattern(scale: number): Number[];
+  createDashPattern(scale: number): string;
 
   /**
-   * Function: createTolerance
-   *
    * Creates a hit detection tolerance shape for the given node.
    */
   createTolerance(node: Element): Element;
 
   /**
-   * Function: createShadow
-   *
    * Creates a shadow for the given node.
    */
   createShadow(node: Element): Element;
 
   /**
-   * Function: setLink
-   *
    * Experimental implementation for hyperlinks.
    */
   setLink(link: string): void;
 
   /**
-   * Function: rotate
-   *
    * Sets the rotation of the canvas. Note that rotation cannot be concatenated.
    */
   rotate(theta: number, flipH: boolean, flipV: boolean, cx: number, cy: number): void;
 
   /**
-   * Function: begin
-   *
    * Extends superclass to create path.
    */
   begin(): void;
 
   /**
-   * Function: rect
-   *
    * Private helper function to create SVG elements
    */
   rect(x: number, y: number, w: number, h: number): void;
 
   /**
-   * Function: roundrect
-   *
    * Private helper function to create SVG elements
    */
   roundrect(x: number, y: number, w: number, h: number, dx: number, dy: number): void;
 
   /**
-   * Function: ellipse
-   *
    * Private helper function to create SVG elements
    */
   ellipse(x: number, y: number, w: number, h: number): void;
 
   /**
-   * Function: image
-   *
    * Private helper function to create SVG elements
    */
   image(x: number, y: number, w: number, h: number, src: string, aspect: boolean, flipH: boolean, flipV: boolean): void;
 
   /**
-   * Function: convertHtml
-   *
    * Converts the given HTML string to XHTML.
    */
   convertHtml(val: string): string;
 
   /**
-   * Function: createDiv
-   *
    * Private helper function to create SVG elements
+   * Note: signature changed in mxgraph 4.1.0
    */
-  createDiv(str: string, align: string, valign: string, style: string, overflow: string): HTMLElement;
-
-  /**
-   * Invalidates the cached offset size for the given node.
-   */
-  invalidateCachedOffsetSize(node: Element): void;
+  createDiv(str: string): HTMLElement;
 
   /**
    * Updates existing DOM nodes for text rendering. LATER: Merge common parts with text function below.
@@ -347,8 +303,28 @@ declare class mxSvgCanvas2D extends mxAbstractCanvas2D {
   updateText(x: number, y: number, w: number, h: number, align: string, valign: string, wrap: string, overflow: string, clip: string, rotation: number, node: Element): void;
 
   /**
-   * Function: text
-   *
+   * Creates a foreignObject for the given string and adds it to the given root.
+   * @since mxgraph 4.1.0
+   */
+  addForeignObject(x: number, y: number, w: number, h: number, align: string, valign: string, wrap: string, format: string, overflow: string, clip: string, rotation: number, dir: any, div: Element, root: Element): void;
+
+  /**
+   * Updates existing DOM nodes for text rendering.
+   */
+  updateTextNodes(x: number, y: number, w: number, h: number, align: string, valign: string, wrap: string, overflow: string, clip: string, rotation: number, g: Element): void;
+
+  /**
+   * Updates existing DOM nodes for text rendering.
+   * @since mxgraph 4.1.0
+   */
+  createCss(w: number, h: number, align: string, valign: string, wrap: string, overflow: string, clip: string, bg: string, border: string | number, flex: string, block: any, s: any, callback: Function): void;
+
+  /**
+   * Private helper function to create SVG elements
+   */
+  getTextCss(): string;
+
+  /**
    * Paints the given text. Possible values for format are empty string for plain
    * text and html for HTML markup. Note that HTML markup is only supported if
    * foreignObject is supported and <foEnabled> is true. (This means IE9 and later
@@ -357,52 +333,38 @@ declare class mxSvgCanvas2D extends mxAbstractCanvas2D {
   text(x: number, y: number, w: number, h: number, str: string, align: string, valign: string, wrap: string, format: string, overflow: string, clip: string, rotation: number, dir: string): void;
 
   /**
-   * Function: createClip
-   *
    * Creates a clip for the given coordinates.
    */
   createClip(x: number, y: number, w: number, h: number): Element;
 
   /**
-   * Function: text
-   *
    * Paints the given text. Possible values for format are empty string for
    * plain text and html for HTML markup.
    */
   plainText(x: number, y: number, w: number, h: number, str: string, align: string, valign: string, wrap: string, overflow: string, clip: string, rotation: number, dir: string): void;
 
   /**
-   * Function: updateFont
-   *
    * Updates the text properties for the given node. (NOTE: For this to work in
    * IE, the given node must be a text or tspan element.)
    */
   updateFont(node: Element): void;
 
   /**
-   * Function: addTextBackground
-   *
    * Background color and border
    */
   addTextBackground(node: Element, str: string, x: number, y: number, w: number, h: number, align: string, valign: string, overflow: string): void;
 
   /**
-   * Function: stroke
-   *
    * Paints the outline of the current path.
    */
   stroke(): void;
 
   /**
-   * Function: fill
-   *
    * Fills the current path.
    */
   fill(): void;
 
   /**
-   * Function: fillAndStroke
-   *
    * Fills and paints the outline of the current path.
    */
   fillAndStroke(): void;

--- a/util/mxVmlCanvas2D.d.ts
+++ b/util/mxVmlCanvas2D.d.ts
@@ -1,159 +1,155 @@
+/**
+ * Implements a canvas to be used for rendering VML. Here is an example of implementing a
+ * fallback for SVG images which are not supported in VML-based browsers.
+ * @example
+ * ```javascript
+ * (code)
+ * var mxVmlCanvas2DImage = mxVmlCanvas2D.prototype.image;
+ * mxVmlCanvas2D.prototype.image = function(x, y, w, h, src, aspect, flipH, flipV)
+ * {
+ *   if (src.substring(src.length - 4, src.length) == '.svg')
+ *   {
+ *     src = 'http://www.jgraph.com/images/mxgraph.gif';
+ *   }
+ *
+ *   mxVmlCanvas2DImage.apply(this, arguments);
+ * };
+ * ```
+ *
+ * To disable anti-aliasing in the output, use the following code.
+ * @example
+ * ```javascript
+ * document.createStyleSheet().cssText = mxClient.VML_PREFIX + '\\:*{antialias:false;)}';
+ * ```
+ *
+ * Note that there is a known issue in VML where gradients are painted using the outer
+ * bounding box of rotated shapes, not the actual bounds of the shape. See
+ * also {@link text} for plain text label restrictions in shapes for VML.
+ */
 declare class mxVmlCanvas2D extends mxAbstractCanvas2D {
   constructor(root: Element);
 
+  /**
+   * Reference to the container for the SVG content.
+   */
+  root: Element;
 
   /**
-   * Variable: path
-   *
    * Holds the current DOM node.
    */
   node: Element;
 
   /**
-   * Variable: textEnabled
-   *
-   * Specifies if text output should be enabledetB. Default is true.
+   * Specifies if text output should be enabled.
+   * @default true
    */
   textEnabled: boolean;
 
   /**
-   * Variable: moveOp
-   *
-   * Contains the string used for moving in paths. Default is 'm'.
+   * Contains the string used for moving in paths.
+   * @default 'm'
    */
   moveOp: string;
 
   /**
-   * Variable: lineOp
-   *
-   * Contains the string used for moving in paths. Default is 'l'.
+   * Contains the string used for moving in paths.
+   * @default 'l'
    */
   lineOp: string;
 
   /**
-   * Variable: curveOp
-   *
-   * Contains the string used for bezier curves. Default is 'c'.
+   * Contains the string used for bezier curves.
+   * @default 'c'
    */
   curveOp: string;
 
   /**
-   * Variable: closeOp
-   *
-   * Holds the operator for closing curves. Default is 'x e'.
+   * Holds the operator for closing curves.
+   * @default 'x'
    */
   closeOp: string;
 
   /**
-   * Variable: rotatedHtmlBackground
-   *
-   * Background color for rotated HTML. Default is ''. This can be set to eg.
+   * Background color for rotated HTML. This can be set to eg.
    * white to improve rendering of rotated text in VML for IE9.
+   * @default ''
    */
   rotatedHtmlBackground: string;
 
   /**
-   * Variable: vmlScale
-   *
    * Specifies the scale used to draw VML shapes.
+   * @default 1
    */
   vmlScale: number;
 
   /**
-   * Function: createElement
-   *
    * Creates the given element using the document.
    */
   createElement(name: string): HTMLElement;
 
   /**
-   * Function: createVmlElement
-   *
-   * Creates a new element using <createElement> and prefixes the given name with
-   * <mxClient.VML_PREFIX>.
+   * Creates a new element using {@link createElement} and prefixes the given name with
+   * {@link mxClient.VML_PREFIX}.
    */
   createVmlElement(name: string): HTMLElement;
 
   /**
-   * Function: addNode
-   *
-   * Adds the current node to the <root>.
+   * Adds the current node to the {@link root}.
    */
   addNode(filled: boolean, stroked: boolean): void;
 
   /**
-   * Function: createTransparentFill
-   *
    * Creates a transparent fill.
    */
   createTransparentFill(): HTMLElement;
 
   /**
-   * Function: createFill
-   *
    * Creates a fill for the current state.
    */
   createFill(): HTMLElement;
+
   /**
-   * Function: createStroke
-   *
    * Creates a fill for the current state.
    */
   createStroke(): HTMLElement;
 
   /**
-   * Function: getVmlDashPattern
-   *
    * Returns a VML dash pattern for the current dashPattern.
    * See http://msdn.microsoft.com/en-us/library/bb264085(v=vs.85).aspx
    */
   getVmlDashStyle(): string;
 
   /**
-   * Function: createShadow
-   *
    * Creates a shadow for the given node.
    */
   createShadow(node: Element, filled: boolean, stroked: boolean): Element;
 
   /**
-   * Function: createShadowFill
-   *
    * Creates the fill for the shadow.
    */
   createShadowFill(): HTMLElement;
 
   /**
-   * Function: createShadowStroke
-   *
    * Creates the stroke for the shadow.
    */
   createShadowStroke(): HTMLElement;
 
   /**
-   * Function: rotate
-   *
    * Sets the rotation of the canvas. Note that rotation cannot be concatenated.
    */
   rotate(theta: number, flipH: boolean, flipV: boolean, cx: number, cy: number): void;
 
   /**
-   * Function: begin
-   *
    * Extends superclass to create path.
    */
   begin(): void;
 
   /**
-   * Function: quadTo
-   *
    * Replaces quadratic curve with bezier curve in VML.
    */
   quadTo(x1: number, y1: number, x2: number, y2: number): void;
 
   /**
-   * Function: createRect
-   *
    * Sets the glass gradient.
    */
   createRect(nodeName: string, x: number, y: number, w: number, h: number): HTMLElement;
@@ -166,36 +162,26 @@ declare class mxVmlCanvas2D extends mxAbstractCanvas2D {
   rect(x: number, y: number, w: number, h: number): void;
 
   /**
-   * Function: roundrect
-   *
    * Sets the current path to a rounded rectangle.
    */
   roundrect(x: number, y: number, w: number, h: number, dx: number, dy: number): void;
 
   /**
-   * Function: ellipse
-   *
    * Sets the current path to an ellipse.
    */
   ellipse(x: number, y: number, w: number, h: number): void;
 
   /**
-   * Function: image
-   *
    * Paints an image.
    */
   image(x: number, y: number, w: number, h: number, src: string, aspect: boolean, flipH: boolean, flipV: boolean): void;
 
   /**
-   * Function: createText
-   *
    * Creates the innermost element that contains the HTML text.
    */
   createDiv(str: string, align: string, valign: string, overflow: string): HTMLElement;
 
   /**
-   * Function: text
-   *
    * Paints the given text. Possible values for format are empty string for plain
    * text and html for HTML markup. Clipping, text background and border are not
    * supported for plain text in VML.
@@ -203,29 +189,21 @@ declare class mxVmlCanvas2D extends mxAbstractCanvas2D {
   text(x: number, y: number, w: number, h: number, str: string, align: string, valign: string, wrap: string, format: string, overflow: string, clip: string, rotation: number, dir: string): void;
 
   /**
-   * Function: plainText
-   *
    * Paints the outline of the current path.
    */
   plainText(x: number, y: number, w: number, h: number, str: string, align: string, valign: string, wrap: string, overflow: string, clip: string, rotation: number, dir: string): void;
 
   /**
-   * Function: stroke
-   *
    * Paints the outline of the current path.
    */
   stroke(): void;
 
   /**
-   * Function: fill
-   *
    * Fills the current path.
    */
   fill(): void;
 
   /**
-   * Function: fillAndStroke
-   *
    * Fills and paints the outline of the current path.
    */
   fillAndStroke(): void;

--- a/util/mxXmlCanvas2D.d.ts
+++ b/util/mxXmlCanvas2D.d.ts
@@ -1,0 +1,397 @@
+declare class mxXmlCanvas2D extends mxAbstractCanvas2D {
+  constructor(root: Element);
+
+  /**
+   * Reference to the container for the SVG content.
+   */
+  root: Element;
+
+  /**
+   * Specifies if text output should be enabled.
+   * @default true
+   */
+  textEnabled: boolean;
+
+  /**
+   * Specifies if the output should be compressed by removing redundant calls.
+   * @default true
+   */
+  compressed: boolean;
+
+  /**
+   * Writes the rendering defaults to {@link root}:
+   */
+  writeDefaults(): void;
+
+  /**
+   * Returns a formatted number with 2 decimal places.
+   */
+  format(value: string): number;
+
+  /**
+   * Creates the given element using the owner document of {@link root}.
+   */
+  createElement(name: string): Element;
+
+  /**
+   * Saves the drawing state.
+   */
+  save(): void;
+
+  /**
+   * Restores the drawing state.
+   */
+  restore(): void;
+
+  /**
+   * Scales the output.
+   *
+   * @param scale Number that represents the scale where 1 is equal to 100%.
+   */
+  scale(value: number): void;
+
+  /**
+   * Translates the output.
+   *
+   * @param dx Number that specifies the horizontal translation.
+   * @param dy Number that specifies the vertical translation.
+   */
+  translate(dx: number, dy: number): void;
+
+  /**
+   * Rotates and/or flips the output around a given center. (Note: Due to
+   * limitations in VML, the rotation cannot be concatenated.)
+   *
+   * @param theta Number that represents the angle of the rotation (in degrees).
+   * @param flipH Boolean indicating if the output should be flipped horizontally.
+   * @param flipV Boolean indicating if the output should be flipped vertically.
+   * @param cx Number that represents the x-coordinate of the rotation center.
+   * @param cy Number that represents the y-coordinate of the rotation center.
+   */
+  rotate(theta: number, flipH: boolean, flipV: boolean, cx: number, cy: number): void;
+
+  /**
+   * Sets the current alpha.
+   *
+   * @param value Number that represents the new alpha. Possible values are between
+   * 1 (opaque) and 0 (transparent).
+   */
+  setAlpha(value: number): void;
+
+  /**
+   * Sets the current fill alpha.
+   *
+   * @param value Number that represents the new fill alpha. Possible values are between
+   * 1 (opaque) and 0 (transparent).
+   */
+  setFillAlpha(value: number): void;
+
+
+  /**
+   * Sets the current stroke alpha.
+   *
+   * @param value Number that represents the new stroke alpha. Possible values are between
+   * 1 (opaque) and 0 (transparent).
+   */
+  setStrokeAlpha(value: number): void;
+
+  /**
+   * Sets the current fill color.
+   *
+   * @param value Hexadecimal representation of the color or 'none'.
+   */
+  setFillColor(value: string): void;
+
+
+  /**
+   * Sets the gradient. Note that the coordinates may be ignored by some implementations.
+   *
+   * @param color1 Hexadecimal representation of the start color.
+   * @param color2 Hexadecimal representation of the end color.
+   * @param x X-coordinate of the gradient region.
+   * @param y y-coordinate of the gradient region.
+   * @param w Width of the gradient region.
+   * @param h Height of the gradient region.
+   * @param direction One of {@link mxConstants.DIRECTION_NORTH}, {@link mxConstants.DIRECTION_EAST},
+   * {@link mxConstants.DIRECTION_SOUTH} or {@link mxConstants.DIRECTION_WEST}.
+   * @param alpha1 Optional alpha of the start color.
+   * @default 1 Possible values
+   * are between 1 (opaque) and 0 (transparent).
+   * @param alpha2 Optional alpha of the end color.
+   * @default 1 Possible values
+   * are between 1 (opaque) and 0 (transparent).
+   */
+  setGradient(color1: string, color2: string, x: number, y: number, w: number, h: number, direction: string, alpha1: number, alpha2: number): void;
+
+  /**
+   * Sets the current stroke color.
+   *
+   * @param value Hexadecimal representation of the color or 'none'.
+   */
+  setStrokeColor(value: string): void;
+
+
+  /**
+   * Sets the current stroke width.
+   *
+   * @param value Numeric representation of the stroke width.
+   */
+  setStrokeWidth(value: number): void;
+
+  /**
+   * Enables or disables dashed lines.
+   *
+   * @param value Boolean that specifies if dashed lines should be enabled.
+   * @param value Boolean that specifies if the stroke width should be ignored
+   * for the dash pattern.
+   * @default false
+   */
+  setDashed(value: boolean, fixDash: boolean): void;
+
+  /**
+   * Sets the current dash pattern.
+   * @default '3 3'
+   *
+   * @param value String that represents the dash pattern, which is a sequence of
+   * numbers defining the length of the dashes and the length of the spaces
+   * between the dashes. The lengths are relative to the line width - a length
+   * of 1 is equals to the line width.
+   */
+  setDashPattern(value: string): void;
+
+  /**
+   * Sets the line cap.
+   * @default 'flat' which corresponds to 'butt' in SVG
+   *
+   * @param value String that represents the line cap. Possible values are flat, round
+   * and square.
+   */
+  setLineCap(value: string): void;
+
+  /**
+   * Sets the line join.
+   * @default 'miter'
+   *
+   * @param value String that represents the line join. Possible values are miter,
+   * round and bevel.
+   */
+  setLineJoin(value: string): void;
+
+  /**
+   * Sets the miter limit.
+   * @default 10
+   *
+   * @param value Number that represents the miter limit.
+   */
+  setMiterLimit(value: number): void;
+
+  /**
+   * Sets the current font color.
+   * @default '#000000'
+   *
+   * @param value Hexadecimal representation of the color or 'none'.
+   */
+  setFontColor(value: string): void;
+
+  /**
+   * Sets the current font background color.
+   *
+   * @param value Hexadecimal representation of the color or 'none'.
+   */
+  setFontBackgroundColor(value: string): void;
+
+  /**
+   * Sets the current font border color.
+   *
+   * @param value Hexadecimal representation of the color or 'none'.
+   */
+  setFontBorderColor(value: string): void;
+
+  /**
+   * Sets the current font size.
+   * @default {@link mxConstants.DEFAULT_FONTSIZE}
+   *
+   * @param value Numeric representation of the font size.
+   */
+  setFontSize(value: number): void;
+
+  /**
+   * Sets the current font family.
+   * @default {@link mxConstants.DEFAULT_FONTFAMILY}
+   *
+   * @param value String representation of the font family. This handles the same
+   * values as the CSS font-family property.
+   */
+  setFontFamily(value: string): void;
+
+  /**
+   * Sets the current font style.
+   *
+   * @param value Numeric representation of the font family. This is the sum of the
+   * font styles from {@link mxConstants}.
+   */
+  setFontStyle(value: string): void;
+
+  /**
+   * Enables or disables shadows.
+   *
+   * @param value Boolean that specifies if shadows should be enabled.
+   */
+  setShadow(value: boolean): void;
+
+  /**
+   * Sets the current shadow color. Default {@link mxConstants.SHADOWCOLOR}
+   *
+   *
+   * @param value Hexadecimal representation of the color or 'none'.
+   */
+  setShadowColor(value: string): void;
+
+  /**
+   * Sets the current shadows alpha. Default is {@link mxConstants.SHADOW_OPACITY}
+   *
+   * @param value Number that represents the new alpha. Possible values are between 1 (opaque) and 0 (transparent).
+   */
+  setShadowAlpha(value: number): void;
+
+  /**
+   * Sets the current shadow offset.
+   *
+   * @param dx Number that represents the horizontal offset of the shadow.
+   * @param dy Number that represents the vertical offset of the shadow.
+   */
+  setShadowOffset(dx: number, dy: number): void;
+
+  /**
+   * Puts a rectangle into the drawing buffer.
+   *
+   * @param x Number that represents the x-coordinate of the rectangle.
+   * @param y Number that represents the y-coordinate of the rectangle.
+   * @param w Number that represents the width of the rectangle.
+   * @param h Number that represents the height of the rectangle.
+   */
+  rect(x: number, y: number, w: number, h: number): void;
+
+  /**
+   * Puts a rounded rectangle into the drawing buffer.
+   *
+   * @param x Number that represents the x-coordinate of the rectangle.
+   * @param y Number that represents the y-coordinate of the rectangle.
+   * @param w Number that represents the width of the rectangle.
+   * @param h Number that represents the height of the rectangle.
+   * @param dx Number that represents the horizontal rounding.
+   * @param dy Number that represents the vertical rounding.
+   */
+  roundrect(x: number, y: number, w: number, h: number, dx: number, dy: number): void;
+
+  /**
+   * Puts an ellipse into the drawing buffer.
+   *
+   * @param x Number that represents the x-coordinate of the ellipse.
+   * @param y Number that represents the y-coordinate of the ellipse.
+   * @param w Number that represents the width of the ellipse.
+   * @param h Number that represents the height of the ellipse.
+   */
+  ellipse(x: number, y: number, w: number, h: number): void;
+
+  /**
+   * Paints an image.
+   *
+   * @param x Number that represents the x-coordinate of the image.
+   * @param y Number that represents the y-coordinate of the image.
+   * @param w Number that represents the width of the image.
+   * @param h Number that represents the height of the image.
+   * @param src String that specifies the URL of the image.
+   * @param aspect Boolean indicating if the aspect of the image should be preserved.
+   * @param flipH Boolean indicating if the image should be flipped horizontally.
+   * @param flipV Boolean indicating if the image should be flipped vertically.
+   */
+  image(x: number, y: number, w: number, h: number, src: string, aspect: boolean, flipH: boolean, flipV: boolean): void;
+
+  /**
+   * Starts a new path and puts it into the drawing buffer.
+   */
+  begin(): void;
+
+  /**
+   * Moves the current path the given point.
+   *
+   * @param x Number that represents the x-coordinate of the point.
+   * @param y Number that represents the y-coordinate of the point.
+   */
+  moveTo(x: number, y: number): void;
+
+  /**
+   * Draws a line to the given coordinates.
+   *
+   * @param x Number that represents the x-coordinate of the endpoint.
+   * @param y Number that represents the y-coordinate of the endpoint.
+   */
+  lineTo(x: number, y: number): void;
+
+  /**
+   * Adds a quadratic curve to the current path.
+   *
+   * @param x1 Number that represents the x-coordinate of the control point.
+   * @param y1 Number that represents the y-coordinate of the control point.
+   * @param x2 Number that represents the x-coordinate of the endpoint.
+   * @param y2 Number that represents the y-coordinate of the endpoint.
+   */
+  quadTo(x1: number, y1: number, x2: number, y2: number): void;
+
+  /**
+   * Adds a bezier curve to the current path.
+   *
+   * @param x1 Number that represents the x-coordinate of the first control point.
+   * @param y1 Number that represents the y-coordinate of the first control point.
+   * @param x2 Number that represents the x-coordinate of the second control point.
+   * @param y2 Number that represents the y-coordinate of the second control point.
+   * @param x3 Number that represents the x-coordinate of the endpoint.
+   * @param y3 Number that represents the y-coordinate of the endpoint.
+   */
+  curveTo(x1: number, y1: number, x2: number, y2: number, x3: number, y3: number): void;
+
+  /**
+   * Closes the current path.
+   */
+  close(): void;
+
+  /**
+   * Paints the given text. Possible values for format are empty string for
+   * plain text and html for HTML markup. Background and border color as well
+   * as clipping is not available in plain text labels for VML. HTML labels
+   * are not available as part of shapes with no foreignObject support in SVG
+   * (eg. IE9, IE10).
+   *
+   * @param x Number that represents the x-coordinate of the text.
+   * @param y Number that represents the y-coordinate of the text.
+   * @param w Number that represents the available width for the text or 0 for automatic width.
+   * @param h Number that represents the available height for the text or 0 for automatic height.
+   * @param str String that specifies the text to be painted.
+   * @param align String that represents the horizontal alignment.
+   * @param valign String that represents the vertical alignment.
+   * @param wrap Boolean that specifies if word-wrapping is enabled. Requires w > 0.
+   * @param format Empty string for plain text or 'html' for HTML markup.
+   * @param overflow Specifies the overflow behaviour of the label. Requires w > 0 and/or h > 0.
+   * @param clip Boolean that specifies if the label should be clipped. Requires w > 0 and/or h > 0.
+   * @param rotation Number that specifies the angle of the rotation around the anchor point of the text.
+   * @param dir Optional string that specifies the text direction. Possible values are rtl and lrt.
+   */
+  text(x: number, y: number, w: number, h: number, str: string, align: string, valign: string, wrap: string, format: string, overflow: string, clip: string, rotation: number, dir: string): void;
+
+  /**
+   * Paints the outline of the current drawing buffer.
+   */
+  stroke(): void;
+
+  /**
+   * Fills the current drawing buffer.
+   */
+  fill(): void;
+
+  /**
+   * Fills the current drawing buffer and its outline.
+   */
+  fillAndStroke(): void;
+
+}


### PR DESCRIPTION
Notice that the TSDoc of common methods are currently documented in `mxXmlCanvas2D` as in the JavaScript mxGraph documentation.
This should be moved to `mxAbstractCanvas2D` and removed from subclasses. This will provide a better documentation (inherited in subclasses). Unfortunately, I don't have time to manage this for now

closes #18