### PR TITLE
Fix mxCellRenderer.registerShape signature

### DIFF
--- a/test.ts
+++ b/test.ts
@@ -1,0 +1,12 @@
+/**
+ * This file is an introduction for adding tests to mxgraph-type-definitions
+ * A larger infrastructure should be setup for a more robust solution: a file per types, in a dedicated subfolder (test
+ * or spec), ...
+ */
+
+// a custom shape without explicit constructor, so inherited from parent class: constructor(stencil: mxStencil)
+class CustomShape extends mxShape {}
+
+// Validate fix for #24
+mxCellRenderer.registerShape("customShape", CustomShape);
+mxCellRenderer.registerShape("customShape", mxActor);

--- a/view/mxCellRenderer.d.ts
+++ b/view/mxCellRenderer.d.ts
@@ -72,23 +72,16 @@ declare class mxCellRenderer {
   forceControlClickHandler: boolean;
 
   /**
-   * Function: registerShape
-   *
-   * Registers the given constructor under the specified key in this instance
-   * of the renderer.
-   *
-   * Example:
-   *
-   * (code)
+   * Registers the given constructor under the specified key in this instance of the renderer.
+   * @example
+   * ```
    * mxCellRenderer.registerShape(mxConstants.SHAPE_RECTANGLE, mxRectangleShape);
-   * (end)
+   * ```
    *
-   * Parameters:
-   *
-   * key - String representing the shape name.
-   * shape - Constructor of the <mxShape> subclass.
+   * @param key the shape name.
+   * @param shape constructor of the {@link mxShape} subclass.
    */
-  static registerShape(key: string, shape: typeof mxShape): void;
+  static registerShape(key: string, shape: new(...args: any) => mxShape): void;
 
   /**
    * Function: initializeShape


### PR DESCRIPTION
Previous signature prevented to pass the shape constructor as the 2nd parameter.
Closes #24

As part of this Pull Request, I propose to start adding tests for the defintions. In this case, this validates that the fix works with 2 usage scenarii.
I don't know if this impact the final npm distrib, so feel free to remove the related commit if this introduces issues. We can introduce tests later.

